### PR TITLE
Support http message v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.2 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0 || ^2.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "rmccue/requests": "^1.8 || ^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^2.0",
         "psr/http-factory": "^1.0",
         "rmccue/requests": "^1.8 || ^2.0"
     },

--- a/src/Psr/HttpClient.php
+++ b/src/Psr/HttpClient.php
@@ -72,10 +72,6 @@ final class HttpClient implements RequestFactoryInterface, StreamFactoryInterfac
      */
     public function createStream(string $content = ''): StreamInterface
     {
-        if (!is_string($content)) {
-            throw InvalidArgument::create(1, '$content', 'string', gettype($content));
-        }
-
         return StringBasedStream::createFromString($content);
     }
 

--- a/src/Psr/MessageHeaderTrait.php
+++ b/src/Psr/MessageHeaderTrait.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Art4\Requests\Psr;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use WpOrg\Requests\Exception\InvalidArgument;
 
@@ -50,7 +51,7 @@ trait MessageHeaderTrait
      *     Each key MUST be a header name, and each value MUST be an array of
      *     strings for that header.
      */
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
@@ -63,12 +64,8 @@ trait MessageHeaderTrait
      *     name using a case-insensitive string comparison. Returns false if
      *     no matching header name is found in the message.
      */
-    public function hasHeader($name)
+    public function hasHeader(string $name): bool
     {
-        if (!is_string($name)) {
-            throw InvalidArgument::create(1, '$name', 'string', gettype($name));
-        }
-
         return array_key_exists(strtolower($name), $this->headerNames);
     }
 
@@ -86,12 +83,8 @@ trait MessageHeaderTrait
      *    header. If the header does not appear in the message, this method MUST
      *    return an empty array.
      */
-    public function getHeader($name)
+    public function getHeader(string $name): array
     {
-        if (!is_string($name)) {
-            throw InvalidArgument::create(1, '$name', 'string', gettype($name));
-        }
-
         if (!array_key_exists(strtolower($name), $this->headers)) {
             return [];
         }
@@ -118,12 +111,8 @@ trait MessageHeaderTrait
      *    concatenated together using a comma. If the header does not appear in
      *    the message, this method MUST return an empty string.
      */
-    public function getHeaderLine($name)
+    public function getHeaderLine(string $name): string
     {
-        if (!is_string($name)) {
-            throw InvalidArgument::create(1, '$name', 'string', gettype($name));
-        }
-
         if (!array_key_exists(strtolower($name), $this->headerNames)) {
             return '';
         }
@@ -146,12 +135,8 @@ trait MessageHeaderTrait
      * @return static
      * @throws \InvalidArgumentException for invalid header names or values.
      */
-    public function withHeader($name, $value)
+    public function withHeader(string $name, $value): MessageInterface
     {
-        if (!is_string($name)) {
-            throw InvalidArgument::create(1, '$name', 'string', gettype($name));
-        }
-
         if (!is_string($value) && !is_array($value)) {
             throw InvalidArgument::create(2, '$value', 'string|array containing strings', gettype($value));
         }
@@ -189,12 +174,8 @@ trait MessageHeaderTrait
      * @throws \InvalidArgumentException for invalid header names.
      * @throws \InvalidArgumentException for invalid header values.
      */
-    public function withAddedHeader($name, $value)
+    public function withAddedHeader(string $name, $value): MessageInterface
     {
-        if (!is_string($name)) {
-            throw InvalidArgument::create(1, '$name', 'string', gettype($name));
-        }
-
         if (!is_string($value) && !is_array($value)) {
             throw InvalidArgument::create(2, '$value', 'string|array containing strings', gettype($value));
         }
@@ -228,12 +209,8 @@ trait MessageHeaderTrait
      * @param string $name Case-insensitive header field name to remove.
      * @return static
      */
-    public function withoutHeader($name)
+    public function withoutHeader(string $name): MessageInterface
     {
-        if (!is_string($name)) {
-            throw InvalidArgument::create(1, '$name', 'string', gettype($name));
-        }
-
         $return = clone($this);
         $return->updateHeader($name, []);
 

--- a/src/Psr/Request.php
+++ b/src/Psr/Request.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Art4\Requests\Psr;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -112,7 +113,7 @@ final class Request implements RequestInterface
      *
      * @return string
      */
-    public function getRequestTarget()
+    public function getRequestTarget(): string
     {
         if ($this->requestTarget !== '') {
             return $this->requestTarget;
@@ -150,14 +151,8 @@ final class Request implements RequestInterface
      * @param mixed $requestTarget
      * @return static
      */
-    public function withRequestTarget($requestTarget)
+    public function withRequestTarget(string $requestTarget): RequestInterface
     {
-        // $requestTarget accepts only string
-        // @see https://github.com/php-fig/http-message/pull/78
-        if (!is_string($requestTarget)) {
-            throw InvalidArgument::create(1, '$requestTarget', 'string', gettype($requestTarget));
-        }
-
         if ($requestTarget === '') {
             $requestTarget = '/';
         }
@@ -173,7 +168,7 @@ final class Request implements RequestInterface
      *
      * @return string Returns the request method.
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -193,12 +188,8 @@ final class Request implements RequestInterface
      * @return static
      * @throws \InvalidArgumentException for invalid HTTP methods.
      */
-    public function withMethod($method)
+    public function withMethod(string $method): RequestInterface
     {
-        if (!is_string($method)) {
-            throw InvalidArgument::create(1, '$method', 'string', gettype($method));
-        }
-
         $request = clone($this);
         $request->method = $method;
 
@@ -214,7 +205,7 @@ final class Request implements RequestInterface
      * @return UriInterface Returns a UriInterface instance
      *     representing the URI of the request.
      */
-    public function getUri()
+    public function getUri(): UriInterface
     {
         return $this->uri;
     }
@@ -249,7 +240,7 @@ final class Request implements RequestInterface
      * @param bool $preserveHost Preserve the original state of the Host header.
      * @return static
      */
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri(UriInterface $uri, bool $preserveHost = false): RequestInterface
     {
         $request = clone($this);
         $request->setUri($uri, $preserveHost);
@@ -264,7 +255,7 @@ final class Request implements RequestInterface
      *
      * @return string HTTP protocol version.
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocolVersion;
     }
@@ -282,12 +273,8 @@ final class Request implements RequestInterface
      * @param string $version HTTP protocol version
      * @return static
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion(string $version): MessageInterface
     {
-        if (!is_string($version)) {
-            throw InvalidArgument::create(1, '$version', 'string', gettype($version));
-        }
-
         $request = clone($this);
         $request->protocolVersion = $version;
 
@@ -299,7 +286,7 @@ final class Request implements RequestInterface
      *
      * @return StreamInterface Returns the body as a stream.
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         return $this->body;
     }
@@ -317,7 +304,7 @@ final class Request implements RequestInterface
      * @return static
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         $request = clone($this);
         $request->body = $body;

--- a/src/Psr/Response.php
+++ b/src/Psr/Response.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Art4\Requests\Psr;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use WpOrg\Requests\Exception\InvalidArgument;
@@ -176,7 +177,7 @@ final class Response implements ResponseInterface
      *
      * @return int Status code.
      */
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->status_code;
     }
@@ -201,16 +202,8 @@ final class Response implements ResponseInterface
      * @return static
      * @throws \InvalidArgumentException For invalid status code arguments.
      */
-    public function withStatus($code, $reasonPhrase = '')
+	public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
     {
-        if (!is_int($code)) {
-            throw InvalidArgument::create(1, '$code', 'int', gettype($code));
-        }
-
-        if (!is_string($reasonPhrase)) {
-            throw InvalidArgument::create(2, '$reasonPhrase', 'string', gettype($reasonPhrase));
-        }
-
         $response = clone($this);
         $response->status_code = $code;
 
@@ -236,7 +229,7 @@ final class Response implements ResponseInterface
      * @link http://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
      * @return string Reason phrase; must return an empty string if none present.
      */
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         if ($this->reasonPhrase !== null) {
             return $this->reasonPhrase;
@@ -256,7 +249,7 @@ final class Response implements ResponseInterface
      *
      * @return string HTTP protocol version.
      */
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol_version;
     }
@@ -274,12 +267,8 @@ final class Response implements ResponseInterface
      * @param string $version HTTP protocol version
      * @return static
      */
-    public function withProtocolVersion($version)
+    public function withProtocolVersion(string $version): MessageInterface
     {
-        if (!is_string($version)) {
-            throw InvalidArgument::create(1, '$version', 'string', gettype($version));
-        }
-
         $response = clone($this);
         $response->protocol_version = $version;
 
@@ -291,7 +280,7 @@ final class Response implements ResponseInterface
      *
      * @return StreamInterface Returns the body as a stream.
      */
-    public function getBody()
+    public function getBody(): StreamInterface
     {
         return $this->body;
     }
@@ -309,7 +298,7 @@ final class Response implements ResponseInterface
      * @return static
      * @throws \InvalidArgumentException When the body is not valid.
      */
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         $response = clone($this);
         $response->body = $body;

--- a/src/Psr/StringBasedStream.php
+++ b/src/Psr/StringBasedStream.php
@@ -70,7 +70,7 @@ final class StringBasedStream implements StreamInterface
      * @see http://php.net/manual/en/language.oop5.magic.php#object.tostring
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->content;
     }
@@ -80,7 +80,7 @@ final class StringBasedStream implements StreamInterface
      *
      * @return void
      */
-    public function close()
+    public function close(): void
     {
         return;
     }
@@ -102,7 +102,7 @@ final class StringBasedStream implements StreamInterface
      *
      * @return int|null Returns the size in bytes if known, or null if unknown.
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         return strlen($this->content);
     }
@@ -113,7 +113,7 @@ final class StringBasedStream implements StreamInterface
      * @return int Position of the file pointer
      * @throws \RuntimeException on error.
      */
-    public function tell()
+    public function tell(): int
     {
         throw new RuntimeException(__METHOD__ . '() is not implemented.');
     }
@@ -123,7 +123,7 @@ final class StringBasedStream implements StreamInterface
      *
      * @return bool
      */
-    public function eof()
+    public function eof(): bool
     {
         return true;
     }
@@ -133,7 +133,7 @@ final class StringBasedStream implements StreamInterface
      *
      * @return bool
      */
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
@@ -150,7 +150,7 @@ final class StringBasedStream implements StreamInterface
      *     SEEK_END: Set position to end-of-stream plus offset.
      * @throws \RuntimeException on failure.
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
         throw new RuntimeException(__METHOD__ . '() is not implemented.');
     }
@@ -165,7 +165,7 @@ final class StringBasedStream implements StreamInterface
      * @link http://www.php.net/manual/en/function.fseek.php
      * @throws \RuntimeException on failure.
      */
-    public function rewind()
+    public function rewind(): void
     {
         throw new RuntimeException(__METHOD__ . '() is not implemented.');
     }
@@ -175,7 +175,7 @@ final class StringBasedStream implements StreamInterface
      *
      * @return bool
      */
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
@@ -187,7 +187,7 @@ final class StringBasedStream implements StreamInterface
      * @return int Returns the number of bytes written to the stream.
      * @throws \RuntimeException on failure.
      */
-    public function write($string)
+    public function write(string $string): int
     {
         throw new RuntimeException(__METHOD__ . '() is not implemented.');
     }
@@ -197,7 +197,7 @@ final class StringBasedStream implements StreamInterface
      *
      * @return bool
      */
-    public function isReadable()
+    public function isReadable(): bool
     {
         return false;
     }
@@ -212,7 +212,7 @@ final class StringBasedStream implements StreamInterface
      *     if no bytes are available.
      * @throws \RuntimeException if an error occurs.
      */
-    public function read($length)
+    public function read(int $length): string
     {
         throw new RuntimeException(__METHOD__ . '() is not implemented.');
     }
@@ -224,7 +224,7 @@ final class StringBasedStream implements StreamInterface
      * @throws \RuntimeException if unable to read or an error occurs while
      *     reading.
      */
-    public function getContents()
+    public function getContents(): string
     {
         throw new RuntimeException(__METHOD__ . '() is not implemented.');
     }
@@ -241,7 +241,7 @@ final class StringBasedStream implements StreamInterface
      *     provided. Returns a specific key value if a key is provided and the
      *     value is found, or null if the key is not found.
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
         if (func_num_args() > 0 && !is_string($key)) {
             throw InvalidArgument::create(1, '$key', 'string', gettype($key));

--- a/src/Psr/Uri.php
+++ b/src/Psr/Uri.php
@@ -78,7 +78,7 @@ final class Uri implements UriInterface
      * @see https://tools.ietf.org/html/rfc3986#section-3.1
      * @return string The URI scheme.
      */
-    public function getScheme()
+    public function getScheme(): string
     {
         return (string) $this->iri->scheme;
     }
@@ -101,7 +101,7 @@ final class Uri implements UriInterface
      * @see https://tools.ietf.org/html/rfc3986#section-3.2
      * @return string The URI authority, in "[user-info@]host[:port]" format.
      */
-    public function getAuthority()
+    public function getAuthority(): string
     {
         return (string) $this->iri->authority;
     }
@@ -121,7 +121,7 @@ final class Uri implements UriInterface
      *
      * @return string The URI user information, in "username[:password]" format.
      */
-    public function getUserInfo()
+    public function getUserInfo(): string
     {
         return (string) $this->iri->userinfo;
     }
@@ -137,7 +137,7 @@ final class Uri implements UriInterface
      * @see http://tools.ietf.org/html/rfc3986#section-3.2.2
      * @return string The URI host.
      */
-    public function getHost()
+    public function getHost(): string
     {
         return (string) $this->iri->host;
     }
@@ -157,7 +157,7 @@ final class Uri implements UriInterface
      *
      * @return null|int The URI port.
      */
-    public function getPort()
+    public function getPort(): ?int
     {
         $port = $this->iri->port;
         $scheme = $this->getScheme();
@@ -205,7 +205,7 @@ final class Uri implements UriInterface
      * @see https://tools.ietf.org/html/rfc3986#section-3.3
      * @return string The URI path.
      */
-    public function getPath()
+    public function getPath(): string
     {
         return (string) $this->iri->path;
     }
@@ -230,7 +230,7 @@ final class Uri implements UriInterface
      * @see https://tools.ietf.org/html/rfc3986#section-3.4
      * @return string The URI query string.
      */
-    public function getQuery()
+    public function getQuery(): string
     {
         return (string) $this->iri->query;
     }
@@ -251,7 +251,7 @@ final class Uri implements UriInterface
      * @see https://tools.ietf.org/html/rfc3986#section-3.5
      * @return string The URI fragment.
      */
-    public function getFragment()
+    public function getFragment(): string
     {
         return (string) $this->iri->fragment;
     }
@@ -271,7 +271,7 @@ final class Uri implements UriInterface
      * @return static A new instance with the specified scheme.
      * @throws \InvalidArgumentException for invalid or unsupported schemes.
      */
-    public function withScheme($scheme)
+    public function withScheme($scheme): UriInterface
     {
         if (!is_string($scheme)) {
             throw InvalidArgument::create(1, '$scheme', 'string', gettype($scheme));
@@ -298,7 +298,7 @@ final class Uri implements UriInterface
      * @param null|string $password The password associated with $user.
      * @return static A new instance with the specified user information.
      */
-    public function withUserInfo($user, $password = null)
+    public function withUserInfo($user, $password = null): UriInterface
     {
         if (!is_string($user)) {
             throw InvalidArgument::create(1, '$user', 'string', gettype($user));
@@ -333,7 +333,7 @@ final class Uri implements UriInterface
      * @return static A new instance with the specified host.
      * @throws \InvalidArgumentException for invalid hostnames.
      */
-    public function withHost($host)
+    public function withHost($host): UriInterface
     {
         if (!is_string($host)) {
             throw InvalidArgument::create(1, '$host', 'string', gettype($host));
@@ -363,7 +363,7 @@ final class Uri implements UriInterface
      * @return static A new instance with the specified port.
      * @throws \InvalidArgumentException for invalid ports.
      */
-    public function withPort($port)
+    public function withPort($port): UriInterface
     {
         if (!is_int($port) && $port !== null) {
             throw InvalidArgument::create(1, '$port', 'null|int in the range of 0 - 65535', is_int($port) ? $port : gettype($port));
@@ -404,7 +404,7 @@ final class Uri implements UriInterface
      * @return static A new instance with the specified path.
      * @throws \InvalidArgumentException for invalid paths.
      */
-    public function withPath($path)
+    public function withPath($path): UriInterface
     {
         if (!is_string($path)) {
             throw InvalidArgument::create(1, '$path', 'string', gettype($path));
@@ -432,7 +432,7 @@ final class Uri implements UriInterface
      * @return static A new instance with the specified query string.
      * @throws \InvalidArgumentException for invalid query strings.
      */
-    public function withQuery($query)
+    public function withQuery($query): UriInterface
     {
         if (!is_string($query)) {
             throw InvalidArgument::create(1, '$query', 'string', gettype($query));
@@ -459,7 +459,7 @@ final class Uri implements UriInterface
      * @param string $fragment The fragment to use with the new instance.
      * @return static A new instance with the specified fragment.
      */
-    public function withFragment($fragment)
+    public function withFragment($fragment): UriInterface
     {
         if (!is_string($fragment)) {
             throw InvalidArgument::create(1, '$fragment', 'string', gettype($fragment));
@@ -495,7 +495,7 @@ final class Uri implements UriInterface
      * @see http://tools.ietf.org/html/rfc3986#section-4.1
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $string = '';
 

--- a/tests/Psr/Request/GetHeaderLineTest.php
+++ b/tests/Psr/Request/GetHeaderLineTest.php
@@ -57,27 +57,6 @@ final class GetHeaderLineTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the getHeaderLine() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::getHeaderLine
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testGetHeaderLineWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::getHeaderLine(): Argument #1 ($name) must be of type string,', Request::class));
-
-        $request->getHeaderLine($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Request/GetHeaderTest.php
+++ b/tests/Psr/Request/GetHeaderTest.php
@@ -57,27 +57,6 @@ final class GetHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the getHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::getHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testGetHeaderWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::getHeader(): Argument #1 ($name) must be of type string,', Request::class));
-
-        $request->getHeader($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Request/HasHeaderTest.php
+++ b/tests/Psr/Request/HasHeaderTest.php
@@ -57,27 +57,6 @@ final class HasHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the hasHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::hasHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testHasHeaderWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::hasHeader(): Argument #1 ($name) must be of type string,', Request::class));
-
-        $request->hasHeader($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Request/WithAddedHeaderTest.php
+++ b/tests/Psr/Request/WithAddedHeaderTest.php
@@ -42,27 +42,6 @@ final class WithAddedHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withAddedHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::withAddedHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithAddedHeaderWithoutNameAsStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withAddedHeader(): Argument #1 ($name) must be of type string', Request::class));
-
-        $request->withAddedHeader($input, 'value');
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Request/WithHeaderTest.php
+++ b/tests/Psr/Request/WithHeaderTest.php
@@ -42,27 +42,6 @@ final class WithHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::withHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithHeaderWithoutNameAsStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withHeader(): Argument #1 ($name) must be of type string', Request::class));
-
-        $request->withHeader($input, 'value');
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Request/WithMethodTest.php
+++ b/tests/Psr/Request/WithMethodTest.php
@@ -42,27 +42,6 @@ final class WithMethodTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withMethod() method received an invalid input type as `$method`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::withMethod
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithMethodWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withMethod(): Argument #1 ($method) must be of type string', Request::class));
-
-        $request->withMethod($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Request/WithProtocolVersionTest.php
+++ b/tests/Psr/Request/WithProtocolVersionTest.php
@@ -42,27 +42,6 @@ final class WithProtocolVersionTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withProtocolVersion() method received an invalid input type as `$method`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::withProtocolVersion
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithProtocolVersionWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withProtocolVersion(): Argument #1 ($version) must be of type string', Request::class));
-
-        $request->withProtocolVersion($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Request/WithRequestTargetTest.php
+++ b/tests/Psr/Request/WithRequestTargetTest.php
@@ -42,27 +42,6 @@ final class WithRequestTargetTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withRequestTarget() method received an invalid input type as `$requestTarget`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::withRequestTarget
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithRequestTargetWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withRequestTarget(): Argument #1 ($requestTarget) must be of type string', Request::class));
-
-        $request->withRequestTarget($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Request/WithoutHeaderTest.php
+++ b/tests/Psr/Request/WithoutHeaderTest.php
@@ -42,27 +42,6 @@ final class WithoutHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withoutHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::withoutHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithoutHeaderWithoutNameAsStringThrowsInvalidArgumentException($input)
-    {
-        $request = Request::withMethodAndUri('GET', $this->createMock(UriInterface::class));
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withoutHeader(): Argument #1 ($name) must be of type string', Request::class));
-
-        $request->withoutHeader($input, 'value');
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Response/GetHeaderLineTest.php
+++ b/tests/Psr/Response/GetHeaderLineTest.php
@@ -57,27 +57,6 @@ final class GetHeaderLineTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the getHeaderLine() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Response::getHeaderLine
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testGetHeaderLineWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $response = Response::fromResponse(new RequestsResponse());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::getHeaderLine(): Argument #1 ($name) must be of type string,', Response::class));
-
-        $response->getHeaderLine($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Response/GetHeaderTest.php
+++ b/tests/Psr/Response/GetHeaderTest.php
@@ -57,27 +57,6 @@ final class GetHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the getHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Response::getHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testGetHeaderWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $response = Response::fromResponse(new RequestsResponse());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::getHeader(): Argument #1 ($name) must be of type string,', Response::class));
-
-        $response->getHeader($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Response/HasHeaderTest.php
+++ b/tests/Psr/Response/HasHeaderTest.php
@@ -57,27 +57,6 @@ final class HasHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the hasHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Response::hasHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testHasHeaderWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $response = Response::fromResponse(new RequestsResponse());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::hasHeader(): Argument #1 ($name) must be of type string,', Response::class));
-
-        $response->hasHeader($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Response/WithAddedHeaderTest.php
+++ b/tests/Psr/Response/WithAddedHeaderTest.php
@@ -42,27 +42,6 @@ final class WithAddedHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withAddedHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Response::withAddedHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithAddedHeaderWithoutNameAsStringThrowsInvalidArgumentException($input)
-    {
-        $response = Response::fromResponse(new RequestsResponse());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withAddedHeader(): Argument #1 ($name) must be of type string', Response::class));
-
-        $response->withAddedHeader($input, 'value');
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Response/WithHeaderTest.php
+++ b/tests/Psr/Response/WithHeaderTest.php
@@ -42,27 +42,6 @@ final class WithHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Response::withHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithHeaderWithoutNameAsStringThrowsInvalidArgumentException($input)
-    {
-        $response = Response::fromResponse(new RequestsResponse());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withHeader(): Argument #1 ($name) must be of type string', Response::class));
-
-        $response->withHeader($input, 'value');
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Response/WithProtocolVersionTest.php
+++ b/tests/Psr/Response/WithProtocolVersionTest.php
@@ -44,28 +44,6 @@ final class WithProtocolVersionTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withProtocolVersion() method received an invalid input type as `$method`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Response::withProtocolVersion
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithProtocolVersionWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $requestsResponse = new RequestsResponse();
-        $response = Response::fromResponse($requestsResponse);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withProtocolVersion(): Argument #1 ($version) must be of type string, ', Response::class));
-
-        $response->withProtocolVersion($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/Response/WithStatusTest.php
+++ b/tests/Psr/Response/WithStatusTest.php
@@ -42,27 +42,6 @@ final class WithStatusTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withStatus() method received an invalid input type as `$code`.
-     *
-     * @dataProvider dataInvalidTypeNotInteger
-     *
-     * @covers \Art4\Requests\Psr\Response::withStatus
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithStatusWithoutIntInCodeThrowsInvalidArgumentException($input)
-    {
-        $response = Response::fromResponse(new RequestsResponse());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withStatus(): Argument #1 ($code) must be of type int, ', Response::class));
-
-        $response = $response->withStatus($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array
@@ -70,27 +49,6 @@ final class WithStatusTest extends TestCase
     public function dataInvalidTypeNotInteger()
     {
         return TypeProviderHelper::getAllExcept(TypeProviderHelper::GROUP_INT);
-    }
-
-    /**
-     * Tests receiving an exception when the withStatus() method received an invalid input type as `$reasonPhrase`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Response::withStatus
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithStatusWithoutStringInReasonPhraseThrowsInvalidArgumentException($input)
-    {
-        $response = Response::fromResponse(new RequestsResponse());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withStatus(): Argument #2 ($reasonPhrase) must be of type string, ', Response::class));
-
-        $response = $response->withStatus(200, $input);
     }
 
     /**

--- a/tests/Psr/Response/WithoutHeaderTest.php
+++ b/tests/Psr/Response/WithoutHeaderTest.php
@@ -42,27 +42,6 @@ final class WithoutHeaderTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withoutHeader() method received an invalid input type as `$name`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Response::withoutHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testWithoutHeaderWithoutNameAsStringThrowsInvalidArgumentException($input)
-    {
-        $response = Response::fromResponse(new RequestsResponse());
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::withoutHeader(): Argument #1 ($name) must be of type string', Response::class));
-
-        $response->withoutHeader($input, 'value');
-    }
-
-    /**
      * Data Provider.
      *
      * @return array

--- a/tests/Psr/StringBasedStream/GetMetadataTest.php
+++ b/tests/Psr/StringBasedStream/GetMetadataTest.php
@@ -40,27 +40,6 @@ final class GetMetadataTest extends TestCase
     }
 
     /**
-     * Tests receiving an exception when the withHeader() method received an invalid input type as `$value`.
-     *
-     * @dataProvider dataInvalidTypeNotString
-     *
-     * @covers \Art4\Requests\Psr\Request::withHeader
-     *
-     * @param mixed $input Invalid parameter input.
-     *
-     * @return void
-     */
-    public function testGetMetadataWithoutStringThrowsInvalidArgumentException($input)
-    {
-        $stream = StringBasedStream::createFromString('');
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('%s::getMetadata(): Argument #1 ($key) must be of type string', StringBasedStream::class));
-
-        $stream->getMetadata($input);
-    }
-
-    /**
      * Data Provider.
      *
      * @return array


### PR DESCRIPTION
* Require `"psr/http-message": "^2.0"`, which requires PHP 7.2
* Method signatures updated where the tests failed
* `is_string()` checks removed
* `InvalidArgumentException` tests removed for corresponding typed function parameters

A proper release should be made on Packagist for #8 #9 before this is merged and released.