### PR TITLE
Drop php 7.1 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: ['ubuntu-latest']
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
     steps:
       - name: Checkout
@@ -25,17 +25,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Install PHP <= 7.1 with composer 2.2.x LTS
-        if: ${{ matrix.php <= '7.1' }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          ini-values: error_reporting=-1, display_errors=On, log_errors_max_len=0
-          coverage: none
-          tools: composer:2.2.*
-
       - name: Install PHP with latest composer
-        if: ${{ matrix.php >= '7.2' }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -45,14 +35,14 @@ jobs:
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
-      - name: "Install Composer dependencies (PHP < 7.2)"
-        if: ${{ matrix.php < '7.2' }}
+      - name: "Install Composer dependencies (PHP < 7.3)"
+        if: ${{ matrix.php < '7.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --prefer-lowest
 
       - name: "Install Composer dependencies (PHP < 8.2)"
-        if: ${{ matrix.php >= '7.2' && matrix.php < '8.2' }}
+        if: ${{ matrix.php >= '7.3' && matrix.php < '8.2' }}
         uses: "ramsey/composer-install@v2"
 
       - name: "Install Composer dependencies (PHP 8.2)"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
   tests:
     name: Tests (PHP ${{ matrix.php }} on ${{ matrix.operating-system }})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.php == '8.2' }}
+    continue-on-error: ${{ matrix.php == '8.3' }}
 
     strategy:
       fail-fast: false
       matrix:
         operating-system: ['ubuntu-latest']
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout
@@ -41,12 +41,12 @@ jobs:
         with:
           composer-options: --prefer-lowest
 
-      - name: "Install Composer dependencies (PHP < 8.2)"
-        if: ${{ matrix.php >= '7.3' && matrix.php < '8.2' }}
+      - name: "Install Composer dependencies (PHP < 8.3)"
+        if: ${{ matrix.php >= '7.3' && matrix.php < '8.3' }}
         uses: "ramsey/composer-install@v2"
 
-      - name: "Install Composer dependencies (PHP 8.2)"
-        if: ${{ matrix.php >= '8.2' }}
+      - name: "Install Composer dependencies (PHP 8.3)"
+        if: ${{ matrix.php >= '8.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Art4/WP-Requests-PSR18-Adapter/compare/1.0.1...HEAD)
 
+### Added
+
+- Add support for PHP 8.2
+
+### Changed
+
+- Drop support for PHP 7.1
+
 ## [1.0.1 - 2023-05-31](https://github.com/Art4/WP-Requests-PSR18-Adapter/compare/1.0.0...1.0.1)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Use [WordPress/Requests](https://github.com/WordPress/Requests) as a [PSR-18](https://www.php-fig.org/psr/psr-18/) HTTP client adapter.
 
-Requires PHP 7.1+
+Requires PHP 7.2+
 
 ## Why?
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ~8.1.0 || ~8.2.0",
+        "php": "^7.2 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.2 || ~8.1.0 || ~8.2.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
This PR will drop support for PHP 7.1 and adds offical support for PHP 8.2.

refs #10 