### PR TITLE
fix: pass URL-encoded body as raw string to preserve repeated params

### DIFF
--- a/.phpstan.neon
+++ b/.phpstan.neon
@@ -23,13 +23,6 @@ parameters:
             count: 1
             path: src/Psr/HttpClient.php
         
-        # parse_str() returns array<int|string, array<mixed>|string> which is compatible
-        # with our array<string,string> return type for prepareRequestData()
-        -
-            message: "#^Method Art4\\\\Requests\\\\Psr\\\\HttpClient\\:\\:prepareRequestData\\(\\) should return array<string, string>\\|string but returns array<int\\|string, array<mixed>\\|string>\\.$#"
-            count: 1
-            path: src/Psr/HttpClient.php
-
         # Method Art4\Requests\Psr\HttpClient::createStreamFromFile() is not yet implemented.
         -
             message: "#^Method Art4\\\\Requests\\\\Psr\\\\HttpClient\\:\\:createStreamFromFile\\(\\) has InvalidArgumentException in PHPDoc \\@throws tag but it\\'s not thrown\\.$#"

--- a/src/Psr/HttpClient.php
+++ b/src/Psr/HttpClient.php
@@ -116,8 +116,12 @@ final class HttpClient implements RequestFactoryInterface, StreamFactoryInterfac
      *
      * Handles differences between Guzzle/PSR-7 and WpOrg\Requests:
      * 1. GET/HEAD/DELETE: Always use empty array (no body)
-     * 2. POST/PUT/PATCH with JSON: Keep as string
-     * 3. Form data: Parse to array if Content-Type is form-urlencoded
+     * 2. All other methods: Keep body as string
+     *
+     * For POST/PUT/PATCH, the body is passed as a raw string regardless of
+     * Content-Type. This ensures URL-encoded bodies with repeated parameter
+     * names (e.g. "text=foo&text=bar") are preserved correctly, since
+     * parse_str() would collapse them into a single value.
      *
      * @param RequestInterface $request
      * @return array<string,string>|string
@@ -141,20 +145,9 @@ final class HttpClient implements RequestFactoryInterface, StreamFactoryInterfac
             return [];
         }
 
-        // Check Content-Type header to determine how to handle the body
-        $contentType = $request->getHeaderLine('Content-Type');
-
-        // If Content-Type is application/x-www-form-urlencoded, parse to array
-        // This allows WpOrg\Requests to properly handle form data
-        if (strpos($contentType, 'application/x-www-form-urlencoded') === 0) {
-            /** @var array<string,string> $parsedData */
-            $parsedData = [];
-            parse_str($body, $parsedData);
-            return $parsedData;
-        }
-
-        // For all other content types (application/json, text/xml, etc.),
-        // return body as string - the transport layer will handle it correctly
+        // Pass body as raw string for all content types.
+        // WpOrg\Requests with data_format='body' (the default for POST/PUT/PATCH)
+        // sends strings as-is in the request body.
         return $body;
     }
 

--- a/src/Psr/HttpClient.php
+++ b/src/Psr/HttpClient.php
@@ -92,7 +92,7 @@ final class HttpClient implements RequestFactoryInterface, StreamFactoryInterfac
         }
 
         $body = $request->getBody()->__toString();
-        $data = $this->prepareRequestData($request);
+        $data = $this->prepareRequestData($request, $body);
 
         // If prepareRequestData dropped a non-empty body, strip Content-Length
         // and Transfer-Encoding so the server doesn't hang waiting for bytes

--- a/src/Psr/HttpClient.php
+++ b/src/Psr/HttpClient.php
@@ -91,8 +91,27 @@ final class HttpClient implements RequestFactoryInterface, StreamFactoryInterfac
             $headers[$key] = $request->getHeaderLine($key);
         }
 
-        // Prepare the request body/data for WpOrg\Requests library
+        $body = $request->getBody()->__toString();
         $data = $this->prepareRequestData($request);
+
+        // If prepareRequestData dropped a non-empty body, strip Content-Length
+        // and Transfer-Encoding so the server doesn't hang waiting for bytes
+        // that will never arrive.
+        if ($data === [] && $body !== '') {
+            foreach (array_keys($headers) as $name) {
+                if (strcasecmp($name, 'Content-Length') === 0 || strcasecmp($name, 'Transfer-Encoding') === 0) {
+                    unset($headers[$name]);
+                }
+            }
+        }
+
+        $options = $this->options;
+        // Force data_format='body' when passing a raw string.
+        // WpOrg\Requests defaults to 'query' for GET/HEAD/DELETE, which calls
+        // http_build_query() on $data and fatals with TypeError if it's a string.
+        if (is_string($data)) {
+            $options['data_format'] = 'body';
+        }
 
         try {
             $response = Requests::request(
@@ -100,7 +119,7 @@ final class HttpClient implements RequestFactoryInterface, StreamFactoryInterfac
                 $headers,
                 $data,
                 $request->getMethod(),
-                $this->options
+                $options
             );
         } catch (Transport $th) {
             throw new NetworkException($request, $th);
@@ -128,26 +147,13 @@ final class HttpClient implements RequestFactoryInterface, StreamFactoryInterfac
      */
     private function prepareRequestData(RequestInterface $request)
     {
-        $method = strtoupper($request->getMethod());
         $body = $request->getBody()->__toString();
 
-        // For GET, HEAD, DELETE requests: never send body data
-        // WpOrg\Requests uses data_format='query' for these methods,
-        // which calls http_build_query() expecting an array
-        if (in_array($method, ['GET', 'HEAD', 'DELETE'], true)) {
-            /** @var array<string,string> */
-            return [];
-        }
-
-        // For requests with empty body, return empty array
         if ($body === '' || $body === '[]') {
             /** @var array<string,string> */
             return [];
         }
 
-        // Pass body as raw string for all content types.
-        // WpOrg\Requests with data_format='body' (the default for POST/PUT/PATCH)
-        // sends strings as-is in the request body.
         return $body;
     }
 

--- a/src/Psr/HttpClient.php
+++ b/src/Psr/HttpClient.php
@@ -143,12 +143,11 @@ final class HttpClient implements RequestFactoryInterface, StreamFactoryInterfac
      * parse_str() would collapse them into a single value.
      *
      * @param RequestInterface $request
+     * @param string $body Pre-stringified request body (avoids stringifying twice).
      * @return array<string,string>|string
      */
-    private function prepareRequestData(RequestInterface $request)
+    private function prepareRequestData(RequestInterface $request, string $body)
     {
-        $body = $request->getBody()->__toString();
-
         if ($body === '' || $body === '[]') {
             /** @var array<string,string> */
             return [];

--- a/tests/Psr/HttpClient/PrepareRequestDataTest.php
+++ b/tests/Psr/HttpClient/PrepareRequestDataTest.php
@@ -205,17 +205,17 @@ final class PrepareRequestDataTest extends TestCase
     }
 
     /**
-     * Tests that POST requests with form-urlencoded body send parsed array.
+     * Tests that POST requests with form-urlencoded body send body as string.
      *
      * @covers \Art4\Requests\Psr\HttpClient::sendRequest
      * @covers \Art4\Requests\Psr\HttpClient::prepareRequestData
      */
-    public function testPostRequestWithFormUrlencodedBodySendsArray(): void
+    public function testPostRequestWithFormUrlencodedBodySendsString(): void
     {
         $transport = $this->createMock(Transport::class);
         $transport->expects(TestCase::once())->method('request')->willReturnCallback(function ($url, $headers, $data, array $options): string {
             TestCase::assertSame('https://example.org/form', $url);
-            TestCase::assertSame(['name' => 'John Doe', 'email' => 'john@example.com'], $data);
+            TestCase::assertSame('name=John+Doe&email=john%40example.com', $data);
             TestCase::assertSame('POST', $options['type']);
 
             return
@@ -239,17 +239,17 @@ final class PrepareRequestDataTest extends TestCase
     }
 
     /**
-     * Tests that POST requests with form-urlencoded charset body send parsed array.
+     * Tests that POST requests with form-urlencoded charset body send body as string.
      *
      * @covers \Art4\Requests\Psr\HttpClient::sendRequest
      * @covers \Art4\Requests\Psr\HttpClient::prepareRequestData
      */
-    public function testPostRequestWithFormUrlencodedCharsetBodySendsArray(): void
+    public function testPostRequestWithFormUrlencodedCharsetBodySendsString(): void
     {
         $transport = $this->createMock(Transport::class);
         $transport->expects(TestCase::once())->method('request')->willReturnCallback(function ($url, $headers, $data, array $options): string {
             TestCase::assertSame('https://example.org/form', $url);
-            TestCase::assertSame(['username' => 'admin', 'password' => 'secret'], $data);
+            TestCase::assertSame('username=admin&password=secret', $data);
             TestCase::assertSame('POST', $options['type']);
 
             return
@@ -266,6 +266,46 @@ final class PrepareRequestDataTest extends TestCase
         $request = $httpClient->createRequest('POST', 'https://example.org/form');
         $request = $request->withHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
         $request = $request->withBody($httpClient->createStream('username=admin&password=secret'));
+
+        $response = $httpClient->sendRequest($request);
+
+        TestCase::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * Tests that POST requests with repeated form-urlencoded params are preserved.
+     *
+     * Some APIs use repeated parameter names (e.g. item=foo&item=bar) to send
+     * arrays. parse_str() would collapse these into a single value, so the
+     * body must be passed as a raw string.
+     *
+     * @covers \Art4\Requests\Psr\HttpClient::sendRequest
+     * @covers \Art4\Requests\Psr\HttpClient::prepareRequestData
+     */
+    public function testPostRequestWithRepeatedFormParamsPreservesAll(): void
+    {
+        $body = 'item=first&item=second&item=third&category=test';
+
+        $transport = $this->createMock(Transport::class);
+        $transport->expects(TestCase::once())->method('request')->willReturnCallback(function ($url, $headers, $data, array $options) use ($body): string {
+            TestCase::assertSame('https://example.org/batch', $url);
+            TestCase::assertSame($body, $data);
+            TestCase::assertSame('POST', $options['type']);
+
+            return
+                'HTTP/1.1 200 OK' . "\r\n" .
+                'Content-Type:application/json' . "\r\n" .
+                "\r\n" .
+                '{"processed":3}';
+        });
+
+        $httpClient = new HttpClient([
+            'transport' => $transport,
+        ]);
+
+        $request = $httpClient->createRequest('POST', 'https://example.org/batch');
+        $request = $request->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+        $request = $request->withBody($httpClient->createStream($body));
 
         $response = $httpClient->sendRequest($request);
 

--- a/tests/Psr/HttpClient/PrepareRequestDataTest.php
+++ b/tests/Psr/HttpClient/PrepareRequestDataTest.php
@@ -76,18 +76,19 @@ final class PrepareRequestDataTest extends TestCase
     }
 
     /**
-     * Tests that HEAD requests with body send empty array.
+     * Tests that HEAD requests with body pass body as string with data_format='body'.
      *
      * @covers \Art4\Requests\Psr\HttpClient::sendRequest
      * @covers \Art4\Requests\Psr\HttpClient::prepareRequestData
      */
-    public function testHeadRequestWithBodySendsEmptyArray(): void
+    public function testHeadRequestWithBodyPassesBodyAsString(): void
     {
         $transport = $this->createMock(Transport::class);
         $transport->expects(TestCase::once())->method('request')->willReturnCallback(function ($url, $headers, $data, array $options): string {
             TestCase::assertSame('https://example.org/', $url);
-            TestCase::assertSame([], $data);
+            TestCase::assertSame('some body', $data);
             TestCase::assertSame('HEAD', $options['type']);
+            TestCase::assertSame('body', $options['data_format']);
 
             return
                 'HTTP/1.1 200 OK' . "\r\n" .
@@ -108,18 +109,19 @@ final class PrepareRequestDataTest extends TestCase
     }
 
     /**
-     * Tests that DELETE requests with body send empty array.
+     * Tests that DELETE requests with body pass body as string with data_format='body'.
      *
      * @covers \Art4\Requests\Psr\HttpClient::sendRequest
      * @covers \Art4\Requests\Psr\HttpClient::prepareRequestData
      */
-    public function testDeleteRequestWithBodySendsEmptyArray(): void
+    public function testDeleteRequestWithBodyPassesBodyAsString(): void
     {
         $transport = $this->createMock(Transport::class);
         $transport->expects(TestCase::once())->method('request')->willReturnCallback(function ($url, $headers, $data, array $options): string {
             TestCase::assertSame('https://example.org/posts/1', $url);
-            TestCase::assertSame([], $data);
+            TestCase::assertSame('ignored', $data);
             TestCase::assertSame('DELETE', $options['type']);
+            TestCase::assertSame('body', $options['data_format']);
 
             return
                 'HTTP/1.1 204 No Content' . "\r\n" .


### PR DESCRIPTION
`parse_str()` collapses repeated parameter names (e.g. `text=foo&text=bar`) into a single value, breaking APIs like DeepL that rely on repeated params to send arrays.

Both the Curl and Fsockopen transports in `WpOrg\Requests` already handle string data correctly when `data_format=body` (the default for POST/PUT/PATCH), so parsing into an array is unnecessary.