### PR TITLE
chore: add PSR-18 compliance tests and findings documentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",
+        "nyholm/psr7": "^1.8",
+        "php-http/client-integration-tests": "^4.0",
         "phpstan/phpstan": "^1.12 || ^2.1",
         "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
         "phpunit/phpunit": "^8.5 || ^9.6 || ^11.5 || ^12.2",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
   <coverage/>
   <testsuite name="default">
     <directory suffix="Test.php">tests</directory>
+    <exclude>
+      <directory suffix="Test.php">tests/Integration</directory>
+    </exclude>
   </testsuite>
   <source>
     <include>

--- a/tests/Integration/HttpClientIntegrationTest.php
+++ b/tests/Integration/HttpClientIntegrationTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Art4\Requests\Tests\Integration;
+
+use Art4\Requests\Psr\HttpClient;
+use Http\Client\Tests\HttpClientTest;
+use Psr\Http\Client\ClientInterface;
+
+final class HttpClientIntegrationTest extends HttpClientTest
+{
+    protected function createHttpAdapter(): ClientInterface
+    {
+        return new HttpClient([
+            'follow_redirects' => false,
+            'timeout' => 5,
+            'connect_timeout' => 5,
+        ]);
+    }
+}

--- a/tests/Integration/SymfonyHttpClientIntegrationTest.php
+++ b/tests/Integration/SymfonyHttpClientIntegrationTest.php
@@ -1,0 +1,421 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Art4\Requests\Tests\Integration;
+
+use Art4\Requests\Psr\HttpClient;
+use GuzzleHttp\Psr7\HttpFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use WpOrg\Requests\Transport\Curl;
+use WpOrg\Requests\Transport\Fsockopen;
+
+/**
+ * Tests inspired by symfony/contracts HttpClientTestCase, ported to PSR-18.
+ *
+ * Uses the vendored Symfony test server router (tests/Integration/symfony-server/index.php).
+ * Server is started once per class in setUpBeforeClass and torn down in tearDownAfterClass.
+ *
+ * @group integration
+ */
+final class SymfonyHttpClientIntegrationTest extends TestCase
+{
+    private const PORT = 8057;
+    private const HOST = '127.0.0.1';
+
+    /** @var resource|null */
+    private static $serverProcess;
+
+    private static RequestFactoryInterface $requestFactory;
+    private static StreamFactoryInterface $streamFactory;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$requestFactory = self::$streamFactory = new HttpFactory();
+        self::startServer();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::stopServer();
+    }
+
+    private static function startServer(): void
+    {
+        $docroot = __DIR__ . '/symfony-server';
+        $cmd = sprintf(
+            'php -dopcache.enable=0 -dvariables_order=EGPCS -S %s:%d -t %s',
+            self::HOST,
+            self::PORT,
+            escapeshellarg($docroot)
+        );
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['file', '/tmp/symfony-test-server.log', 'a'],
+            2 => ['file', '/tmp/symfony-test-server.log', 'a'],
+        ];
+        self::$serverProcess = proc_open($cmd, $descriptors, $pipes);
+        fclose($pipes[0]);
+
+        // Wait for server to accept connections (up to 5s)
+        $start = microtime(true);
+        while (microtime(true) - $start < 5.0) {
+            $sock = @fsockopen(self::HOST, self::PORT, $errno, $errstr, 0.2);
+            if ($sock) {
+                fclose($sock);
+                return;
+            }
+            usleep(50000);
+        }
+        throw new \RuntimeException("Symfony test server failed to start on " . self::HOST . ":" . self::PORT);
+    }
+
+    private static function stopServer(): void
+    {
+        if (is_resource(self::$serverProcess)) {
+            $status = proc_get_status(self::$serverProcess);
+            if ($status['running'] ?? false) {
+                // SIGTERM — proc_terminate uses SIGTERM by default
+                proc_terminate(self::$serverProcess);
+            }
+            proc_close(self::$serverProcess);
+        }
+        self::$serverProcess = null;
+    }
+
+    private function client(array $options = []): HttpClient
+    {
+        $transport = (getenv('REQUESTS_TRANSPORT') ?: 'curl') === 'fsockopen'
+            ? Fsockopen::class
+            : Curl::class;
+
+        return new HttpClient(array_merge([
+            'timeout' => 5,
+            'connect_timeout' => 5,
+            'transport' => $transport,
+        ], $options));
+    }
+
+    private function url(string $path): string
+    {
+        return 'http://' . self::HOST . ':' . self::PORT . $path;
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testDnsError
+     *
+     * PSR-18 §1: "If the request cannot be sent due to a network failure of any
+     * kind, including a timeout, a NetworkExceptionInterface MUST be thrown."
+     *
+     * DNS resolution failure is the canonical network error.
+     */
+    public function testDnsError(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', 'http://does.not.exist.symfony.test/');
+
+        $this->expectException(NetworkExceptionInterface::class);
+        $this->client()->sendRequest($request);
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testConnectTimeout / testTimeoutOnAccess
+     *
+     * Connecting to a closed port should produce a NetworkException, not a
+     * RequestException.
+     */
+    public function testConnectionRefused(): void
+    {
+        // Port 1 is reserved (TCPMUX) and almost certainly not listening
+        $request = self::$requestFactory->createRequest('GET', 'http://127.0.0.1:1/');
+
+        $this->expectException(NetworkExceptionInterface::class);
+        $this->client(['connect_timeout' => 2])->sendRequest($request);
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testHeadRequest
+     *
+     * HEAD to /head returns a body-less response with X-Request-Vars header
+     * containing a JSON dump of the SERVER vars.
+     */
+    public function testHeadRequest(): void
+    {
+        $request = self::$requestFactory->createRequest('HEAD', $this->url('/head'));
+
+        $response = $this->client()->sendRequest($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertNotEmpty($response->getHeaderLine('X-Request-Vars'));
+        $vars = json_decode($response->getHeaderLine('X-Request-Vars'), true);
+        $this->assertSame('HEAD', $vars['REQUEST_METHOD']);
+        // Body must be empty for HEAD
+        $this->assertSame('', $response->getBody()->__toString());
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testRedirectAfterPost
+     *
+     * POST to /302 with a body should follow the redirect, switch to GET, and
+     * drop the body / Content-Length / Content-Type. Final response from / is
+     * the JSON dump of the GET request vars (no body sent).
+     */
+    public function testRedirectAfterPost(): void
+    {
+        $body = self::$streamFactory->createStream('foo=bar');
+        $request = self::$requestFactory->createRequest('POST', $this->url('/302'))
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($body);
+
+        $response = $this->client(['follow_redirects' => true])->sendRequest($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $vars = json_decode($response->getBody()->__toString(), true);
+        $this->assertSame('GET', $vars['REQUEST_METHOD'], 'Method should switch to GET after 302');
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testRedirect307
+     *
+     * 307 must preserve the original method and body. POST to /307 follows
+     * to /post, which still receives a POST.
+     */
+    public function testRedirect307KeepsPostMethod(): void
+    {
+        $body = self::$streamFactory->createStream('{"foo":"bar"}');
+        $request = self::$requestFactory->createRequest('POST', $this->url('/307'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($body);
+
+        $response = $this->client(['follow_redirects' => true])->sendRequest($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $payload = json_decode($response->getBody()->__toString(), true);
+        $this->assertSame('POST', $payload['REQUEST_METHOD'], '307 must preserve POST method');
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testRelativeRedirect
+     *
+     * Server responds with `Location: ..` (relative). Adapter should resolve
+     * it against the request URL.
+     */
+    public function testRelativeRedirect(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/302/relative'));
+
+        $response = $this->client(['follow_redirects' => true])->sendRequest($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        // Final URL after `..` resolution should be /
+        $vars = json_decode($response->getBody()->__toString(), true);
+        $this->assertSame('/', $vars['REQUEST_URI'] ?? null);
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testChunkedEncoding
+     *
+     * Server sends a chunked-encoded body. Adapter must transparently
+     * dechunk it.
+     */
+    public function testChunkedEncoding(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/chunked'));
+
+        $response = $this->client()->sendRequest($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('Symfony is awesome!', $response->getBody()->__toString());
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testGzipBroken
+     *
+     * Server claims Content-Encoding: gzip but sends plain text. Adapter
+     * should either fail cleanly (RequestException) or surface the broken
+     * payload — but must not crash or hang.
+     */
+    public function testGzipBroken(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/gzip-broken'));
+
+        try {
+            $response = $this->client()->sendRequest($request);
+            // If no exception, body should have been delivered (possibly malformed)
+            $this->assertSame(200, $response->getStatusCode());
+        } catch (\Psr\Http\Client\ClientExceptionInterface $e) {
+            // Equally acceptable: surface as a client exception
+            $this->assertNotEmpty($e->getMessage());
+        }
+    }
+
+    /**
+     * Probes the cURL+HEAD+body hang documented in
+     * docs/head-body-hang-2026-04-16.md. With the patched adapter
+     * (data_format='body' workaround) the body is forwarded to the transport;
+     * Curl's transport then drops it but keeps Content-Length, server hangs.
+     */
+    public function testHeadRequestWithBody(): void
+    {
+        $body = self::$streamFactory->createStream('arbitrary-body-bytes');
+        $request = self::$requestFactory->createRequest('HEAD', $this->url('/head'))
+            ->withHeader('Content-Type', 'application/octet-stream')
+            ->withBody($body);
+
+        $response = $this->client(['timeout' => 3])->sendRequest($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('', $response->getBody()->__toString());
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testMaxRedirects
+     *
+     * Default redirect cap should kick in. /302 redirects to /, which 200s,
+     * so a single redirect should still succeed when redirects=1 is allowed.
+     * To exhaust the cap, we'd need a redirect loop; instead we set
+     * redirects=0 and expect the adapter to surface a "too many redirects"
+     * style failure (or expose the 302 directly).
+     */
+    public function testMaxRedirectsZero(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/302'));
+
+        try {
+            $response = $this->client(['follow_redirects' => true, 'redirects' => 0])->sendRequest($request);
+            // If the adapter surfaces the 302 itself instead of throwing, that's
+            // also a reasonable interpretation of "redirects=0".
+            $this->assertSame(302, $response->getStatusCode());
+        } catch (\Psr\Http\Client\ClientExceptionInterface $e) {
+            $this->assertStringContainsStringIgnoringCase('redirect', $e->getMessage());
+        }
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testInvalidRedirect
+     *
+     * Server responds with `Location: //?foo=bar` (schema-relative). The
+     * adapter / underlying Requests should resolve this against the request
+     * URL and follow it, ending up back at the test server root.
+     */
+    public function testSchemaRelativeRedirect(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/301/invalid'));
+
+        $response = $this->client(['follow_redirects' => true])->sendRequest($request);
+
+        // The redirect target resolves to a URL on the same authority. Either
+        // it's followed cleanly (200) or it surfaces as a parse error somewhere.
+        // We just want to make sure the adapter doesn't crash.
+        $this->assertContains($response->getStatusCode(), [200, 301, 302, 400]);
+    }
+
+    /**
+     * Server's /301/bad-tld responds with `Location: http://foo.example.`
+     * Following the redirect should produce a NetworkException (DNS will
+     * fail on the target).
+     */
+    public function testRedirectToBadTldSurfacesNetworkException(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/301/bad-tld'));
+
+        $this->expectException(NetworkExceptionInterface::class);
+        $this->client(['follow_redirects' => true])->sendRequest($request);
+    }
+
+    /**
+     * Basic 404 handling — server returns 404 with empty body.
+     * Adapter must not throw; PSR-18 only throws for transport / protocol
+     * errors, not HTTP error status codes.
+     */
+    public function test404(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/404'));
+
+        $response = $this->client()->sendRequest($request);
+
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('application/json', $response->getHeaderLine('Content-Type'));
+    }
+
+    /**
+     * POST with JSON body. Server's /post endpoint decodes the body as JSON,
+     * merges with REQUEST_METHOD, and echoes back as JSON.
+     */
+    public function testPostJson(): void
+    {
+        $payload = ['hello' => 'world', 'n' => 42];
+        $body = self::$streamFactory->createStream(json_encode($payload));
+        $request = self::$requestFactory->createRequest('POST', $this->url('/post'))
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody($body);
+
+        $response = $this->client()->sendRequest($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $decoded = json_decode($response->getBody()->__toString(), true);
+        $this->assertSame('POST', $decoded['REQUEST_METHOD']);
+        $this->assertSame('world', $decoded['hello']);
+        $this->assertSame(42, $decoded['n']);
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testLengthBroken
+     *
+     * Server sends `Content-Length: 1000` but no body. Adapter behavior
+     * depends on transport — should either throw or surface a short body,
+     * but must not hang past the timeout.
+     */
+    public function testLengthBroken(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/length-broken'));
+        $start = microtime(true);
+
+        try {
+            $response = $this->client(['timeout' => 3])->sendRequest($request);
+            $this->assertSame(200, $response->getStatusCode());
+        } catch (\Psr\Http\Client\ClientExceptionInterface $e) {
+            $this->assertNotEmpty($e->getMessage());
+        }
+
+        // Whatever the outcome, must not block past timeout
+        $elapsed = microtime(true) - $start;
+        $this->assertLessThan(4.0, $elapsed, 'Request must not hang past timeout');
+    }
+
+    /**
+     * Symfony equivalent: HttpClientTestCase::testTimeoutOnHeader
+     *
+     * Server sleeps 300ms before responding. With a 5s timeout, the request
+     * should succeed cleanly.
+     */
+    public function testTimeoutHeaderUnderLimit(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/timeout-header'));
+
+        $response = $this->client(['timeout' => 5])->sendRequest($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * Server sleeps 300ms before responding. With a 100ms timeout, a
+     * NetworkException must be thrown (timeout is a network failure per
+     * PSR-18 §1).
+     */
+    public function testTimeoutThrowsNetworkException(): void
+    {
+        $request = self::$requestFactory->createRequest('GET', $this->url('/timeout-header'));
+
+        $this->expectException(NetworkExceptionInterface::class);
+        // 0.1s = 100ms: server sleeps 300ms, so this must time out
+        $this->client(['timeout' => 0.1, 'connect_timeout' => 0.1])->sendRequest($request);
+    }
+}

--- a/tests/Integration/symfony-server/index.php
+++ b/tests/Integration/symfony-server/index.php
@@ -1,0 +1,235 @@
+<?php
+
+/*
+ * Vendored from symfony/contracts @ 8ee171bf490d93dfd1e4bdd83babae480f016ff5
+ *   HttpClient/Test/Fixtures/web/index.php
+ *
+ * MIT License — Copyright (c) Fabien Potencier <fabien@symfony.com>
+ * https://github.com/symfony/contracts/blob/main/LICENSE
+ *
+ * Local modifications: none. This file is the entry point for the PHP
+ * built-in server used by SymfonyHttpClientIntegrationTest.
+ */
+
+if ('cli-server' !== \PHP_SAPI) {
+    // safe guard against unwanted execution
+    throw new \Exception("You cannot run this script directly, it's a fixture for TestHttpServer.");
+}
+
+$vars = [];
+
+if (!$_POST) {
+    $_POST = json_decode(file_get_contents('php://input'), true);
+    $_POST['content-type'] = $_SERVER['HTTP_CONTENT_TYPE'] ?? '?';
+}
+
+$headers = [
+    'SERVER_PROTOCOL',
+    'SERVER_NAME',
+    'REQUEST_URI',
+    'REQUEST_METHOD',
+    'PHP_AUTH_USER',
+    'PHP_AUTH_PW',
+    'REMOTE_ADDR',
+    'REMOTE_PORT',
+];
+
+foreach ($headers as $k) {
+    if (isset($_SERVER[$k])) {
+        $vars[$k] = $_SERVER[$k];
+    }
+}
+
+foreach ($_SERVER as $k => $v) {
+    if (str_starts_with($k, 'HTTP_')) {
+        $vars[$k] = $v;
+    }
+}
+
+$json = json_encode($vars, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+
+switch (parse_url($vars['REQUEST_URI'], \PHP_URL_PATH)) {
+    default:
+        exit;
+
+    case '/head':
+        header('X-Request-Vars: '.json_encode($vars, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE));
+        header('Content-Length: '.strlen($json), true);
+        break;
+
+    case '/':
+    case '/?a=a&b=b':
+    case 'http://127.0.0.1:8057/':
+    case 'http://localhost:8057/':
+        ob_start('ob_gzhandler');
+        break;
+
+    case '/103':
+        header('HTTP/1.1 103 Early Hints');
+        header('Link: </style.css>; rel=preload; as=style', false);
+        header('Link: </script.js>; rel=preload; as=script', false);
+        flush();
+        usleep(1000);
+        echo "HTTP/1.1 200 OK\r\n";
+        echo "Date: Fri, 26 May 2017 10:02:11 GMT\r\n";
+        echo "Content-Length: 13\r\n";
+        echo "\r\n";
+        echo 'Here the body';
+        exit;
+
+    case '/404':
+        header('Content-Type: application/json', true, 404);
+        break;
+
+    case '/404-gzipped':
+        header('Content-Type: text/plain', true, 404);
+        ob_start('ob_gzhandler');
+        @ob_flush();
+        flush();
+        usleep(300000);
+        echo 'some text';
+        exit;
+
+    case '/301':
+        if ('Basic Zm9vOmJhcg==' === ($vars['HTTP_AUTHORIZATION'] ?? null)) {
+            header('Location: http://127.0.0.1:8057/302', true, 301);
+        }
+        break;
+
+    case '/301/bad-tld':
+        header('Location: http://foo.example.', true, 301);
+        break;
+
+    case '/301/invalid':
+        header('Location: //?foo=bar', true, 301);
+        break;
+
+    case '/301/proxy':
+    case 'http://localhost:8057/301/proxy':
+    case 'http://127.0.0.1:8057/301/proxy':
+        header('Location: http://localhost:8057/', true, 301);
+        break;
+
+    case '/302':
+        if (!isset($vars['HTTP_AUTHORIZATION'])) {
+            $location = $_GET['location'] ?? 'http://localhost:8057/';
+            header('Location: '.$location, true, 302);
+        }
+        break;
+
+    case '/302/relative':
+        header('Location: ..', true, 302);
+        break;
+
+    case '/304':
+        header('Content-Length: 10', true, 304);
+        echo '12345';
+
+        return;
+
+    case '/304/etag':
+        if (isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
+            header('ETag: "abc123"', true, 304);
+            exit;
+        }
+        header('ETag: "abc123"');
+        break;
+
+    case '/307':
+        header('Location: http://localhost:8057/post', true, 307);
+        break;
+
+    case '/length-broken':
+        header('Content-Length: 1000');
+        break;
+
+    case '/post':
+        $output = json_encode(($_POST ?? []) + ['REQUEST_METHOD' => $vars['REQUEST_METHOD']], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
+        header('Content-Type: application/json', true);
+        header('Content-Length: '.strlen($output));
+        echo $output;
+        exit;
+
+    case '/timeout-header':
+        usleep(300000);
+        break;
+
+    case '/timeout-body':
+        echo '<1>';
+        @ob_flush();
+        flush();
+        usleep(500000);
+        echo '<2>';
+        exit;
+
+    case '/timeout-long':
+        ignore_user_abort(false);
+        sleep(1);
+        while (true) {
+            echo '<1>';
+            @ob_flush();
+            flush();
+            usleep(500);
+        }
+        exit;
+
+    case '/chunked':
+        header('Transfer-Encoding: chunked');
+        echo "8\r\nSymfony \r\n5\r\nis aw\r\n6\r\nesome!\r\n0\r\n\r\n";
+        exit;
+
+    case '/chunked-broken':
+        header('Transfer-Encoding: chunked');
+        echo "8\r\nSymfony \r\n5\r\nis aw\r\n6\r\ne";
+        exit;
+
+    case '/gzip-broken':
+        header('Content-Encoding: gzip');
+        echo str_repeat('-', 1000);
+        exit;
+
+    case '/max-duration':
+        ignore_user_abort(false);
+        while (true) {
+            echo '<1>';
+            @ob_flush();
+            flush();
+            usleep(500);
+        }
+        exit;
+
+    case '/json':
+        header('Content-Type: application/json');
+        echo json_encode([
+            'documents' => [
+                ['id' => '/json/1'],
+                ['id' => '/json/2'],
+                ['id' => '/json/3'],
+            ],
+        ]);
+        exit;
+
+    case '/json/1':
+    case '/json/2':
+    case '/json/3':
+        header('Content-Type: application/json');
+        echo json_encode([
+            'title' => $vars['REQUEST_URI'],
+        ]);
+
+        exit;
+
+    case '/custom':
+        if (isset($_GET['status'])) {
+            http_response_code((int) $_GET['status']);
+        }
+        if (isset($_GET['headers']) && is_array($_GET['headers'])) {
+            foreach ($_GET['headers'] as $header) {
+                header($header);
+            }
+        }
+}
+
+header('Content-Type: application/json', true);
+
+echo $json;


### PR DESCRIPTION
This branch adds two integration test classes for PSR-18 compliance:

- `HttpClientIntegrationTest`: uses [`php-http/client-integration-tests`](https://github.com/php-http/client-integration-tests) v4.0.0 (51 tests)
- `SymfonyHttpClientIntegrationTest`: 17 tests ported from [Symfony's `HttpClientTestCase`](https://github.com/symfony/contracts/blob/main/HttpClient/Test/HttpClientTestCase.php) to PSR-18

They are excluded from the default phpunit run. To run them:

```sh
# php-http suite (needs a local server)
php -S 127.0.0.1:10000 -t vendor/php-http/client-integration-tests/fixture &
TEST_SERVER='http://127.0.0.1:10000/server.php' vendor/bin/phpunit tests/Integration/HttpClientIntegrationTest.php
kill %1

# Symfony suite (starts its own server)
vendor/bin/phpunit tests/Integration/SymfonyHttpClientIntegrationTest.php

# Switch transport
REQUESTS_TRANSPORT=fsockopen vendor/bin/phpunit tests/Integration/SymfonyHttpClientIntegrationTest.php
```

Running against `main` I found four issues:

1. Network errors (DNS, connection refused, timeout) get reported as `RequestException` instead of `NetworkException`. PSR-18 spec violation, both transports. Fix is one extra `catch` in `sendRequest()`.

2. Body on GET/HEAD/DELETE causes a hang (Content-Length sent without body). Can be fixed in the adapter with `data_format='body'` (see @GautamMKGarg's [workaround](https://github.com/GautamMKGarg/psr-for-wordpress/commit/fd20ce5f6b0a7276d5a06e4fcf78b2d32c81aae7)). HEAD on Curl still needs a one-line fix upstream in `WordPress/Requests`.

3. 302 redirect after POST keeps POST instead of switching to GET. Upstream `WpOrg\Requests` behavior (only converts on 303). Could be mitigated with a `requests.before_redirect` hook.

4. Schema-relative redirect (`Location: //...`) gives a transport error. Edge case, low impact.

The first one is the easiest to fix, I can open a separate PR for it. The others need upstream input.
